### PR TITLE
新しいPostbox作ってそこにぶっこむ

### DIFF
--- a/mikutter-webapi-hardpoint.rb
+++ b/mikutter-webapi-hardpoint.rb
@@ -17,8 +17,9 @@ Plugin.create(:"mikutter-webapi-hardpoint") {
       # 指定されたタイトルとURLをポストボックスに突っ込む
       webapi("test") { |req, res|
         message = ">#{req.query["title"].force_encoding("UTF-8")}\n#{req.query["url"].force_encoding("UTF-8")}\n"
-        
-        Plugin[:gtk].widgetof(Plugin::GUI::Postbox::cuscaded.values.first).post.buffer.text = message
+        postbox = Plugin::GUI::Postbox.instance
+        postbox.options = {header: message, delegate_other: false}
+        Plugin::GUI::Window.instance(:default) << postbox
       }
 
       Thread.new {


### PR DESCRIPTION
できればGtkを直接使わないほうがいいんですが、Postboxの内容をダイナミックに書き換えるには今のところこの方法しかないです。
このpull-reqではちょっと仕様を変えていて、Windowの上に新しいPostboxを作成して、その中に投稿する内容を入れます。

![20160221095453](https://cloud.githubusercontent.com/assets/586906/13200200/4be6cfda-d881-11e5-8ab3-2ce2a9cb9e1d.png)

フォーカスはPostboxが作られた時にそれに移ります。投稿すると、新しく作られた方のPostboxは削除されるようになっています。
好みもあると思いますが、こっちのほうが書いてる途中の内容が上書きされないなど、メリットは多いと思います。
